### PR TITLE
Add `install` Makefile target to setup Hodor tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,22 @@ down:
 
 pull:
 	docker-compose pull
+
+install: volumes/hodor volumes/hodor/vendor volumes/hodor/config/config.test.php
+
+install-composer:
+	docker-compose run --rm php install
+
+install-config:
+	docker-compose run --rm php install-test-docker
+
+volumes/hodor:
+	mkdir -p volumes
+	cd volumes && \
+		git clone git@github.com:lightster/hodor.git
+
+volumes/hodor/vendor:
+	$(MAKE) install-composer
+
+volumes/hodor/config/config.test.php:
+	$(MAKE) install-config


### PR DESCRIPTION
I am trying to make the dev/test environment setup more and more
seamless and automated

Issue #1 